### PR TITLE
Moved $field['sanitize'] check into fields loop

### DIFF
--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -571,11 +571,11 @@ class RationalOptionPages {
 		
 		if ( !empty( $page['sections'] ) ) {
 			foreach ( $page['sections'] as $section ) {
-				if ( isset( $field['sanitize'] ) && !$field['sanitize'] ) {
-					continue;
-				}
 				if ( !empty( $section['fields'] ) ) {
 					foreach ( $section['fields'] as $field ) {
+						if ( isset( $field['sanitize'] ) && !$field['sanitize'] ) {
+							continue;
+						}
 						switch ( $field['type'] ) {
 							case 'checkbox':
 								if ( empty( $input[ $field['id'] ] ) ) {


### PR DESCRIPTION
The check for $field['sanitize'] was above the loop that iterates the fields.  It was ignoring the setting.